### PR TITLE
Startup launcher should contain full path

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -780,7 +780,7 @@ void MainWindow::setWallpaperOfTheDay() {
 // run app at startup
 void MainWindow::run_onstartup(bool enabled) {
 
-  QString launcher = QApplication::applicationFilePath().split("/").last();
+  QString launcher = QApplication::applicationFilePath();
   QString launcher_name = QApplication::applicationName();
   QString data = "[Desktop Entry]\n"
                  "Type=Application\n"


### PR DESCRIPTION
Its better in general to launch from full paths
rather from command for reliability.

A use case is
1. When someone installs from source, he'd not be having "bing-wall" command available, so to give
them startup launching ability, its better to launch from full path
2. An ordinary user is not affected by this change.