### PR TITLE
fix: compile error, no more tooltip for mouse position

### DIFF
--- a/src/controlbutton.cpp
+++ b/src/controlbutton.cpp
@@ -17,8 +17,5 @@ bool controlButton::eventFilter(QObject *obj, QEvent *event) {
 
 void controlButton::mouseMoveEvent(QMouseEvent *e) {
 
-  QToolTip::showText(this->mapToGlobal(e->position().toPoint()),
-                     this->toolTip());
-
   QPushButton::mouseMoveEvent(e);
 }


### PR DESCRIPTION
# Problem
- Every morning I update my home Arch system at home and then my work Arch system; the Arch laptop on the weekends.
- For several weeks now, my updates fail with the following error (for every Arch computer):
```
src/controlbutton.cpp: In member function ‘virtual void controlButton::mouseMoveEvent(QMouseEvent*)’:
src/controlbutton.cpp:20:43: error: ‘class QMouseEvent’ has no member named ‘position’
   20 |   QToolTip::showText(this->mapToGlobal(e->position().toPoint()),
      |                                           ^~~~~~~~
make: *** [Makefile:736: controlbutton.o] Error 1
```

# Solution
- Remove the `tool-tip` feature that requires the mouse position. 
- Apparently the `QmouseEvent` dependency is broken. I have remove the offending line.  `BingWall` now compiles.